### PR TITLE
ENH:  Enable Python Support by default

### DIFF
--- a/{{cookiecutter.project_name}}/CMakeLists.txt
+++ b/{{cookiecutter.project_name}}/CMakeLists.txt
@@ -85,7 +85,7 @@ option(Slicer_BUILD_DIFFUSION_SUPPORT           "Build application with Diffusio
 option(Slicer_BUILD_EXTENSIONMANAGER_SUPPORT    "Build application with ExtensionManager support"     OFF)
 option(Slicer_BUILD_MULTIVOLUME_SUPPORT         "Build application with MultiVolume support"          OFF)
 option(Slicer_BUILD_PARAMETERSERIALIZER_SUPPORT "Build application with parameter serializer support" OFF)
-option(Slicer_USE_PYTHONQT                      "Build application with Python support"               OFF)
+option(Slicer_USE_PYTHONQT                      "Build application with Python support"               ON)
 option(Slicer_USE_QtTesting                     "Build application with QtTesting support"            OFF)
 option(Slicer_USE_SimpleITK                     "Build application with SimpleITK support"            OFF)
 


### PR DESCRIPTION
This is needed for Python modules, both built in and custom