### PR TITLE
Slicer_BUILD_DICOM_SUPPORT

### DIFF
--- a/{{cookiecutter.project_name}}/CMakeLists.txt
+++ b/{{cookiecutter.project_name}}/CMakeLists.txt
@@ -84,7 +84,7 @@ if(WIN32)
   option(Slicer_BUILD_WIN32_CONSOLE             "Build application executable as a console app"       OFF)
 endif()
 
-option(Slicer_BUILD_DICOM_SUPPORT               "Build application with DICOM support"                OFF)
+option(Slicer_BUILD_DICOM_SUPPORT               "Build application with DICOM support"                ON)
 option(Slicer_BUILD_DIFFUSION_SUPPORT           "Build application with Diffusion support"            OFF)
 option(Slicer_BUILD_EXTENSIONMANAGER_SUPPORT    "Build application with ExtensionManager support"     OFF)
 option(Slicer_BUILD_MULTIVOLUME_SUPPORT         "Build application with MultiVolume support"          OFF)


### PR DESCRIPTION
Slicer_BUILD_DICOM_SUPPORT  option should be on by default. Every customized 3D Slicer application will need to load Dicom data.