### PR TITLE
BUG:  Added About action to HelpMenu (was missing)

### DIFF
--- a/{{cookiecutter.project_name}}/Applications/{{cookiecutter.app_name}}App/q{{cookiecutter.app_name}}AppMainWindow.cxx
+++ b/{{cookiecutter.project_name}}/Applications/{{cookiecutter.app_name}}App/q{{cookiecutter.app_name}}AppMainWindow.cxx
@@ -65,6 +65,9 @@ void q{{cookiecutter.app_name}}AppMainWindowPrivate::setupUi(QMainWindow * mainW
   // to "QMetaObject::connectSlotsByName()" done in "setupUi()" to
   // successfully connect each slot with its corresponding action.
   this->Superclass::setupUi(mainWindow);
+  
+  //Add Help Menu Action
+  this->HelpMenu->addAction(helpAboutSlicerAppAction);
 
   //----------------------------------------------------------------------------
   // Configure

--- a/{{cookiecutter.project_name}}/Applications/{{cookiecutter.app_name}}App/q{{cookiecutter.app_name}}AppMainWindow.cxx
+++ b/{{cookiecutter.project_name}}/Applications/{{cookiecutter.app_name}}App/q{{cookiecutter.app_name}}AppMainWindow.cxx
@@ -66,7 +66,7 @@ void q{{cookiecutter.app_name}}AppMainWindowPrivate::setupUi(QMainWindow * mainW
   // successfully connect each slot with its corresponding action.
   this->Superclass::setupUi(mainWindow);
   
-  //Add Help Menu Action
+  // Add Help Menu Action
   this->HelpMenu->addAction(helpAboutSlicerAppAction);
 
   //----------------------------------------------------------------------------


### PR DESCRIPTION
The About dialog action must be added to the HelpMenu QMenu, it is not added automatically.  Without any actions the help menu throws an error.

