### PR TITLE
COMP: Disable application update support by default

### DIFF
--- a/{{cookiecutter.project_name}}/Applications/{{cookiecutter.app_name}}App/Resources/Settings/DefaultSettings.ini
+++ b/{{cookiecutter.project_name}}/Applications/{{cookiecutter.app_name}}App/Resources/Settings/DefaultSettings.ini
@@ -1,5 +1,8 @@
 [General]
 
+[ApplicationUpdate]
+ServerUrl=https://download.slicer.org
+
 [MainWindow]
 DontConfirmExit=1024
 DontConfirmRestart=1024

--- a/{{cookiecutter.project_name}}/Applications/{{cookiecutter.app_name}}App/Resources/Settings/DefaultSettings.ini
+++ b/{{cookiecutter.project_name}}/Applications/{{cookiecutter.app_name}}App/Resources/Settings/DefaultSettings.ini
@@ -1,7 +1,7 @@
 [General]
 
 [ApplicationUpdate]
-ServerUrl=https://download.slicer.org
+ServerUrl=
 
 [MainWindow]
 DontConfirmExit=1024

--- a/{{cookiecutter.project_name}}/CMakeLists.txt
+++ b/{{cookiecutter.project_name}}/CMakeLists.txt
@@ -86,6 +86,7 @@ endif()
 
 # Slicer options
 option(BUILD_TESTING                            "Build application test suite"                        ON)
+option(Slicer_BUILD_APPLICATIONUPDATE_SUPPORT   "Build application update support"                    OFF)
 option(Slicer_BUILD_DOCUMENTATION               "Build documentation (Doxygen, sphinx, ...)"          OFF)
 if(WIN32)
   option(Slicer_BUILD_WIN32_CONSOLE_LAUNCHER    "Build ${PROJECT_NAME} launcher executable as a console app on windows (displays console at application start)" OFF)


### PR DESCRIPTION
Corresponding Slicer commit:
https://github.com/Slicer/Slicer/commit/3ce46788cde6d74167cd5bb7639855dc1e59401e

Custom applications can either disable application updates or set a different default update server URL.