### PR TITLE
COMP: Update Main.cxx to explicitly include configure headers for used macros

### DIFF
--- a/{{cookiecutter.project_name}}/Applications/{{cookiecutter.app_name}}App/Main.cxx
+++ b/{{cookiecutter.project_name}}/Applications/{{cookiecutter.app_name}}App/Main.cxx
@@ -22,6 +22,8 @@
 // Slicer includes
 #include "qSlicerApplication.h"
 #include "qSlicerApplicationHelper.h"
+#include "vtkSlicerConfigure.h" // For Slicer_MAIN_PROJECT_APPLICATION_NAME
+#include "vtkSlicerVersionConfigure.h" // For Slicer_MAIN_PROJECT_VERSION_FULL
 
 namespace
 {


### PR DESCRIPTION
This fixes a regression introduced in 451194ac6 (COMP: Remove obsolete version header includes) and apply a fix similar to 8c2143ee9 (COMP: Explicitly include version header where associated macros are used)

See https://discourse.slicer.org/t/custom-app-compile-error-slicer-main-project-version-full-undefined/30577