### PR TITLE
COMP: Fix commit-message workflow integration with private repository

### DIFF
--- a/.github/workflows/commit-message.yml
+++ b/.github/workflows/commit-message.yml
@@ -12,7 +12,8 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   check-commit-message:
-    uses: Slicer/Slicer/.github/workflows/commit-message.yml@80a7735c1a419a31ec3131815efe77ad9e0a89f0 # main
+    uses: Slicer/Slicer/.github/workflows/commit-message.yml@f2b79dcfcbf628695607cfa68789d1c0143de2c0 # main

--- a/{{cookiecutter.project_name}}/.github/workflows/commit-message.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/commit-message.yml
@@ -12,7 +12,8 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   check-commit-message:
-    uses: Slicer/Slicer/.github/workflows/commit-message.yml@80a7735c1a419a31ec3131815efe77ad9e0a89f0 # main
+    uses: Slicer/Slicer/.github/workflows/commit-message.yml@f2b79dcfcbf628695607cfa68789d1c0143de2c0 # main


### PR DESCRIPTION
Updates the "pre-commit" workflow to ensure compatibility when reused in a private repository by addressing pull request permissions.

The adjusted repository permissions allows to support the `gsactions/commit-message-checker` action , which relies on GraphQL requiring permission similar to the "Get a Pull Request" REST endpoint.

It fixes the following error encountered during testing, indicating a permissions issue:

```
> Run gsactions/commit-message-checker@16fa2d5de096ae0d35626443bcd24f1e756cafee
> Error: GraphqlResponseError: Request failed due to following response errors:
> - Resource not accessible by integration
```

List of Slicer changes:

```
$ git shortlog 80a7735c1a..f2b79dcfcb --no-merges
Jean-Christophe Fillion-Robin (1):
      BUG: Update "pre-commit" workflow to support reuse from private project
```