### PR TITLE
ENH: Refactor HomeWidget to support custom toolbars

### DIFF
--- a/{{cookiecutter.project_name}}/.ruff.toml
+++ b/{{cookiecutter.project_name}}/.ruff.toml
@@ -69,3 +69,8 @@ isort.known-first-party = [
   "Resources",
 ]
 pydocstyle.convention = "pep257"
+
+[lint.per-file-ignores]
+# Disable "RUF012: Mutable class attributes should be annotated"
+# to allow convenient declaration of instance variables in the HomeWidget class.
+"Modules/Scripted/Home/Home.py" = ["RUF012"]


### PR DESCRIPTION
Improves the `HomeWidget` class by introducing convenient functions to managing custom toolbars in the application:

- Adds `toolbarNames` property to dynamically manage toolbar names
- Refactors the `modifyWindowUI` method to create and manage multiple custom toolbars, introducing the following functions:
  - `insertToolBar`: Helper method to insert a new custom toolbar between existing ones.
  - `initializeSettingsToolBar`: Creates the settings toolbar with the gear icon button to toggle visibility of the settings dialog.
