### PR TITLE
BUG: Fix annotation type associated with _toolbars variable

### DIFF
--- a/{{cookiecutter.project_name}}/Modules/Scripted/Home/Home.py
+++ b/{{cookiecutter.project_name}}/Modules/Scripted/Home/Home.py
@@ -1,4 +1,3 @@
-from collections.abc import Mapping
 from typing import Optional
 
 import qt
@@ -44,7 +43,7 @@ class HomeWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     def toolbarNames(self) -> list[str]:
         return [str(k) for k in self._toolbars]
 
-    _toolbars: Mapping[str, qt.QToolBar] = {}
+    _toolbars: dict[str, qt.QToolBar] = {}
 
     def __init__(self, parent: Optional[qt.QWidget]):
         """Called when the application opens the module the first time and the widget is initialized."""


### PR DESCRIPTION
Follow-up of 91c17c7 ("ENH: Refactor HomeWidget to support custom toolbars", 2024-08-21) updating the annotation to use the mutable type `dict` usable as annotation type in Python >= 3.9.