### PR TITLE
ENH: Add input validation for app name

### DIFF
--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -1,0 +1,15 @@
+import re
+import sys
+
+APP_NAME_REGEX = r"^[a-zA-Z0-9]+$"
+
+app_name = "{{ cookiecutter.app_name }}"
+
+if not re.match(APP_NAME_REGEX, app_name):
+    print(
+        f"ERROR: {app_name} is not a valid app name. "
+        "Only alphanumeric characters are allowed."
+    )
+
+    # exits with status 1 to indicate failure
+    sys.exit(1)


### PR DESCRIPTION
This closes #102.

Per https://cookiecutter.readthedocs.io/en/stable/advanced/hooks.html#examples:

> A pre_gen_project hook can validate template variables. 

I have used this method to return an exit failure if an app_name is provided with anything other than alphanumeric characters.

```
  [1/12] project_name (SlicerCustomAppTemplate): 3D Slicer
  [2/12] github_organization (Kitware):
  [3/12] github_project (3D Slicer):
  [4/12] org_domain (kitware.com):
  [5/12] org_name (Kitware, Inc.):
  [6/12] app_name (3D Slicer):
  [7/12] bundle_identifier (com.kitware.3d slicer):
  [8/12] app_version_major (0):
  [9/12] app_version_minor (1):
  [10/12] app_version_patch (0):
  [11/12] app_description_summary (Customized version of Slicer):
  [12/12] cdash_drop_site (open.cdash.org):
ERROR: 3D Slicer is not a valid app name. Only alphanumeric characters are allowed.
ERROR: Stopping generation because pre_gen_project hook script didn't exit successfully
Hook script failed (exit status: 1)
```