### PR TITLE
COMP: Add missing qMRMLWidget header file

### DIFF
--- a/{{cookiecutter.project_name}}/Applications/{{cookiecutter.app_name}}App/q{{cookiecutter.app_name}}AppMainWindow.cxx
+++ b/{{cookiecutter.project_name}}/Applications/{{cookiecutter.app_name}}App/q{{cookiecutter.app_name}}AppMainWindow.cxx
@@ -28,6 +28,7 @@
 #include "qSlicerAboutDialog.h"
 #include "qSlicerMainWindow_p.h"
 #include "qSlicerModuleSelectorToolBar.h"
+#include "qMRMLWidget.h"
 
 //-----------------------------------------------------------------------------
 // q{{cookiecutter.app_name}}AppMainWindowPrivate methods


### PR DESCRIPTION
This commit resolves the following error encountered during the custom app build process, by addressing changes introduced in Slicer/Slicer@fb6fb19. This change ensures the custom app build system works with the latest Slicer versions.

```
>C:\W\MPs\Applications\CustomApp\qCustomAppMainWindow.cxx(83,24): error C2653: 'qMRMLWidget': is not a class or namespace name [C:\W\MPR_Test\Slicer-build\Applications\CustomApp\qCustomApp.vcxproj]
>C:\W\MPs\Applications\CustomApp\qCustomAppMainWindow.cxx(83,37): error C3861: 'pixmapFromIcon': identifier not found [C:\W\MPR_Test\Slicer-build\Applications\CustomApp\qCustomApp.vcxproj]
```